### PR TITLE
[feat] 좋아요 등록시 각 컨텐츠 별 좋아요 수 증가/감소 기능 구현

### DIFF
--- a/core-service/src/main/java/com/microsoftwo/clother/adviceBoard/command/domain/repository/BoardCommandRepository.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/adviceBoard/command/domain/repository/BoardCommandRepository.java
@@ -12,4 +12,8 @@ public interface BoardCommandRepository extends JpaRepository<BoardEntity, Integ
     @Modifying
     @Query("UPDATE BoardEntity b SET b.likeCount = b.likeCount + 1 WHERE b.id = :boardId")
     void increaseLikeCount(Integer boardId);
+
+    @Modifying
+    @Query("UPDATE BoardEntity b SET b.likeCount = b.likeCount - 1 WHERE b.id = :boardId")
+    void decreaseLikeCount(Integer boardId);
 }

--- a/core-service/src/main/java/com/microsoftwo/clother/adviceBoard/command/domain/repository/BoardCommandRepository.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/adviceBoard/command/domain/repository/BoardCommandRepository.java
@@ -2,9 +2,14 @@ package com.microsoftwo.clother.adviceBoard.command.domain.repository;
 
 import com.microsoftwo.clother.adviceBoard.command.domain.aggregate.BoardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardCommandRepository extends JpaRepository<BoardEntity, Integer> {
-
+    @Modifying
+    @Query("UPDATE BoardEntity b SET b.likeCount = b.likeCount + 1 WHERE b.id = :boardId")
+    void increaseLikeCount(Integer boardId);
 }

--- a/core-service/src/main/java/com/microsoftwo/clother/comment/command/application/dto/CommentDTO.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/comment/command/application/dto/CommentDTO.java
@@ -1,6 +1,7 @@
 package com.microsoftwo.clother.comment.command.application.dto;
 
 import com.microsoftwo.clother.comment.command.domain.aggregate.Comment;
+import jakarta.persistence.Column;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ public class CommentDTO {
     private String content;
     private LocalDateTime createdAt;
     private Boolean isDeleted = false;
+    private int likeCount;
 
     public static CommentDTO fromEntity(Comment comment) {
         return CommentDTO.builder()
@@ -30,6 +32,7 @@ public class CommentDTO {
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .isDeleted(comment.getIsDeleted())
+                .likeCount(comment.getLikeCount())
                 .build();
     }
 
@@ -42,6 +45,7 @@ public class CommentDTO {
                 .content(this.content)
                 .isDeleted(this.isDeleted != null ? this.isDeleted : false)
                 .createdAt(this.createdAt != null ? this.createdAt : LocalDateTime.now())
+                .likeCount(this.likeCount)
                 .build();
     }
 }

--- a/core-service/src/main/java/com/microsoftwo/clother/comment/command/domain/aggregate/Comment.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/comment/command/domain/aggregate/Comment.java
@@ -33,6 +33,9 @@ public class Comment {
     private String content; // 댓글 내용
 
     @Column(nullable = false)
+    private int likeCount = 0;
+
+    @Column(nullable = false)
     private LocalDateTime createdAt; // 작성 시간
 
     @Column(nullable = false)

--- a/core-service/src/main/java/com/microsoftwo/clother/comment/command/domain/repository/CommentRepository.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/comment/command/domain/repository/CommentRepository.java
@@ -11,4 +11,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("UPDATE Comment b SET b.likeCount = b.likeCount + 1 WHERE b.id = :commentId")
     void increaseLikeCount(Integer commentId);
+
+    @Modifying
+    @Query("UPDATE Comment b SET b.likeCount = b.likeCount - 1 WHERE b.id = :commentId")
+    void decreaseLikeCount(Integer commentId);
 }

--- a/core-service/src/main/java/com/microsoftwo/clother/comment/command/domain/repository/CommentRepository.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/comment/command/domain/repository/CommentRepository.java
@@ -2,8 +2,13 @@ package com.microsoftwo.clother.comment.command.domain.repository;
 
 import com.microsoftwo.clother.comment.command.domain.aggregate.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Modifying
+    @Query("UPDATE Comment b SET b.likeCount = b.likeCount + 1 WHERE b.id = :commentId")
+    void increaseLikeCount(Integer commentId);
 }

--- a/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/controller/LikeRegistController.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/controller/LikeRegistController.java
@@ -14,9 +14,9 @@ public class LikeRegistController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<LikeDTO> createLike(@RequestBody LikeDTO likeDTO) {
-        System.out.println(likeDTO.toString());
-        return ResponseEntity.ok(likeService.createLike(likeDTO));
+    public ResponseEntity<Void> createLike(@RequestBody LikeDTO likeDTO) {
+        likeService.createLike(likeDTO);
+        return ResponseEntity.ok().build(); // or 201 Created
     }
 
     @DeleteMapping("/{id}")

--- a/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/controller/LikeRegistController.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/controller/LikeRegistController.java
@@ -23,7 +23,6 @@ public class LikeRegistController {
     public ResponseEntity<Void> deleteLike(@PathVariable int id) {
         likeService.deleteLike(id);
 
-
         return ResponseEntity.noContent().build(); // 204 No Content 응답 반환
     }
 

--- a/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/dto/LikeDTO.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/dto/LikeDTO.java
@@ -12,9 +12,11 @@ import lombok.*;
 public class LikeDTO {
     private int id;
     private int userId;
+
     private Integer postId;
     private Integer boardId;
     private Integer commentId;
+
 
 
     public static LikeDTO fromEntity(Like like) {

--- a/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/service/LikeService.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/service/LikeService.java
@@ -1,9 +1,12 @@
 package com.microsoftwo.clother.likes.command.application.service;
 
+import com.microsoftwo.clother.adviceBoard.command.domain.repository.BoardCommandRepository;
 import com.microsoftwo.clother.adviceBoard.query.service.BoardQueryServiceImpl;
+import com.microsoftwo.clother.comment.command.domain.repository.CommentRepository;
 import com.microsoftwo.clother.likes.command.application.dto.LikeDTO;
 import com.microsoftwo.clother.likes.command.domain.aggregate.Like;
 import com.microsoftwo.clother.likes.command.domain.repository.LikeRepository;
+import com.microsoftwo.clother.post.command.domain.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,18 +16,42 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeService {
 
     private final LikeRepository likeRepository;
-    private final BoardQueryServiceImpl boardQueryService;
+    private final BoardCommandRepository boardCommandRepository ;
+    private final PostRepository postRepository ;
+    private final CommentRepository commentRepository ;
 
     @Transactional
-    public LikeDTO createLike(LikeDTO likeDTO) {
+    public void createLike(LikeDTO likeDTO) {
+
+        Integer userId = likeDTO.getUserId();
+        Integer boardId = likeDTO.getBoardId();
+        Integer postId = likeDTO.getPostId();
+        Integer commentId = likeDTO.getCommentId();
+
+        //  중복 좋아요 체크
+        boolean alreadyExists =
+                (boardId != null && likeRepository.existsByUserIdAndBoardId(userId, boardId)) ||
+                        (postId != null && likeRepository.existsByUserIdAndPostId(userId, postId)) ||
+                        (commentId != null && likeRepository.existsByUserIdAndCommentId(userId, commentId));
+
+
+        if (alreadyExists) {
+            throw new IllegalStateException("이미 좋아요를 누르셨습니다.");
+        }
+
+        // 좋아요 저장
         Like like = likeDTO.toEntity();
-        Like savedLike = likeRepository.save(like);
+        likeRepository.save(like);
 
-        // post에 요청
+        // 좋아요 수 증가 로직
+        if (boardId != null) {
+            boardCommandRepository.increaseLikeCount(boardId);
+        } else if (postId != null) {
+            postRepository.increaseLikeCount(postId);
+        } else if (commentId != null) {
+            commentRepository.increaseLikeCount(commentId);
+        }
 
-        // adviceBoard에 요청
-
-        return LikeDTO.fromEntity(savedLike);
     }
 
     @Transactional

--- a/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/service/LikeService.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/likes/command/application/service/LikeService.java
@@ -20,6 +20,8 @@ public class LikeService {
     private final PostRepository postRepository ;
     private final CommentRepository commentRepository ;
 
+
+    // 좋아요 등록
     @Transactional
     public void createLike(LikeDTO likeDTO) {
 
@@ -54,15 +56,28 @@ public class LikeService {
 
     }
 
+
+    // 좋아요 등록 해제
     @Transactional
     public void deleteLike(int id) {
-        if (likeRepository.existsById(id)) {
-            likeRepository.deleteById(id); // JPA를 활용한 ID로 삭제
-        } else {
-            throw new IllegalArgumentException("좋아요 ID를 찾을 수 없습니다: " + id);
+        Like like = likeRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("좋아요 ID를 찾을 수 없습니다: " + id));
+
+        // 좋아요수 감소
+        if (like.getBoardId() != null) {
+            boardCommandRepository.decreaseLikeCount(like.getBoardId());
+        } else if (like.getPostId() != null) {
+            postRepository.decreaseLikeCount(like.getPostId());
+        } else if (like.getCommentId() != null) {
+            commentRepository.decreaseLikeCount(like.getCommentId());
         }
 
+        // 좋아요 감소
+        likeRepository.deleteById(id);
+
     }
+
+
 }
 
 

--- a/core-service/src/main/java/com/microsoftwo/clother/likes/command/domain/repository/LikeRepository.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/likes/command/domain/repository/LikeRepository.java
@@ -4,4 +4,11 @@ import com.microsoftwo.clother.likes.command.domain.aggregate.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
+//    boolean existsByUserId(Integer userId, Integer boardId, Integer postId, Integer commentId);
+
+    boolean existsByUserIdAndBoardId(Integer userId, Integer boardId);
+
+    boolean existsByUserIdAndPostId(Integer userId, Integer postId);
+
+    boolean existsByUserIdAndCommentId(Integer userId, Integer commentId);
 }

--- a/core-service/src/main/java/com/microsoftwo/clother/post/command/domain/repository/PostRepository.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/post/command/domain/repository/PostRepository.java
@@ -12,4 +12,8 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
     @Modifying
     @Query("UPDATE PostEntity b SET b.likeCount = b.likeCount + 1 WHERE b.id = :postId")
     void increaseLikeCount(Integer postId);
+
+    @Modifying
+    @Query("UPDATE PostEntity b SET b.likeCount = b.likeCount - 1 WHERE b.id = :postId")
+    void decreaseLikeCount(Integer postId);
 }

--- a/core-service/src/main/java/com/microsoftwo/clother/post/command/domain/repository/PostRepository.java
+++ b/core-service/src/main/java/com/microsoftwo/clother/post/command/domain/repository/PostRepository.java
@@ -3,8 +3,13 @@ package com.microsoftwo.clother.post.command.domain.repository;
 
 import com.microsoftwo.clother.post.command.domain.aggregate.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Integer> {
+    @Modifying
+    @Query("UPDATE PostEntity b SET b.likeCount = b.likeCount + 1 WHERE b.id = :postId")
+    void increaseLikeCount(Integer postId);
 }

--- a/core-service/src/main/resources/com/microsoftwo/clother/comment/query/mapper/CommentMapper.xml
+++ b/core-service/src/main/resources/com/microsoftwo/clother/comment/query/mapper/CommentMapper.xml
@@ -10,6 +10,7 @@
         <result property="createDate" column="created_at"/>
         <result property="isDeleted" column="is_deleted"/>
         <result property="parentId" column="parent_id"/>
+        <result property="likeCount" column="like_count"/>
     </resultMap>
 
     <select id="findCommentByType" resultType="com.microsoftwo.clother.comment.query.dto.CommentDTO">
@@ -25,6 +26,7 @@
              , CREATED_AT  AS CREATED_DATE
              , IS_DELETED  AS IS_DELETED
              , PARENT_ID   AS PARENT_ID
+             , LIKE_COUNT
           FROM COMMENT
          WHERE (
                     (#{type} = 'post'    AND POST_ID   = #{id})


### PR DESCRIPTION
## #️⃣연관된 이슈

close #87 

## 📝작업 내용

좋아요 등록 시: 해당 컨텐츠(게시판/포스트/댓글)의 likeCount 컬럼 자동 증가합니다.
좋아요 해제 시: 해당 컨텐츠의 likeCount 자동 감소합니다.
중복 좋아요 방지하였습니다.

## 💬리뷰 요구사항

수정해야 할 것 있으면 알려주세요 !
