### PR TITLE
[feat] 인증 코드 발송 시 문구 추가

### DIFF
--- a/user-server/src/main/java/com/microsoftwo/clother/email/controller/EmailController.java
+++ b/user-server/src/main/java/com/microsoftwo/clother/email/controller/EmailController.java
@@ -1,6 +1,7 @@
 package com.microsoftwo.clother.email.controller;
 
 import com.microsoftwo.clother.email.dto.EmailCheckDTO;
+import com.microsoftwo.clother.email.dto.EmailResponseDTO;
 import com.microsoftwo.clother.email.service.EmailServiceImpl;
 import com.microsoftwo.clother.email.vo.EmailRequestVO;
 import com.microsoftwo.clother.user.service.UserService;
@@ -23,7 +24,7 @@ public class EmailController {
 
     // 인증 코드 전송
     @PostMapping
-    public String mailSend(@RequestBody @Valid EmailRequestVO emailRequestVO) {
+    public EmailResponseDTO mailSend(@RequestBody @Valid EmailRequestVO emailRequestVO) {
         return mailService.joinEmail(emailRequestVO.getEmail());
     }
 

--- a/user-server/src/main/java/com/microsoftwo/clother/email/dto/EmailResponseDTO.java
+++ b/user-server/src/main/java/com/microsoftwo/clother/email/dto/EmailResponseDTO.java
@@ -1,0 +1,13 @@
+package com.microsoftwo.clother.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class EmailResponseDTO {
+    private String message;
+    private int authNumber;
+}

--- a/user-server/src/main/java/com/microsoftwo/clother/email/service/EmailService.java
+++ b/user-server/src/main/java/com/microsoftwo/clother/email/service/EmailService.java
@@ -1,10 +1,11 @@
 package com.microsoftwo.clother.email.service;
 
+import com.microsoftwo.clother.email.dto.EmailResponseDTO;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface EmailService {
-    String joinEmail(String email);
+    EmailResponseDTO joinEmail(String email);
 
     boolean CheckAuthNum(String email, String authNum);
 

--- a/user-server/src/main/java/com/microsoftwo/clother/email/service/EmailServiceImpl.java
+++ b/user-server/src/main/java/com/microsoftwo/clother/email/service/EmailServiceImpl.java
@@ -1,6 +1,7 @@
 package com.microsoftwo.clother.email.service;
 
 import com.microsoftwo.clother.email.config.RedisUtil;
+import com.microsoftwo.clother.email.dto.EmailResponseDTO;
 import com.microsoftwo.clother.user.service.UserService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -41,7 +42,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    public String joinEmail(String email) {
+    public EmailResponseDTO joinEmail(String email) {
         makeRandomNumber();
         String setFrom = "\"Clother Admin\" <yushiii002@gmail.com>";
         String toMail = email;
@@ -50,14 +51,13 @@ public class EmailServiceImpl implements EmailService {
         try {
             // HTML 템플릿 로드
             String content = loadHtmlTemplate();
-
-            // 템플릿에 인증 번호 삽입
             content = content.replace("${authNumber}", String.valueOf(authNumber));
 
             // 이메일 발송
             mailSend(setFrom, toMail, title, content);
 
-            return Integer.toString(authNumber);
+            // DTO 객체로 응답 반환
+            return new EmailResponseDTO("인증 코드가 이메일로 발송되었습니다", authNumber);
         } catch (IOException e) {
             e.printStackTrace();
             return null;

--- a/user-server/src/main/java/com/microsoftwo/clother/user/service/UserServiceImpl.java
+++ b/user-server/src/main/java/com/microsoftwo/clother/user/service/UserServiceImpl.java
@@ -43,12 +43,12 @@ public class UserServiceImpl implements UserService {
         Optional<UserEntity> existingUser = userRepository.findByEmailOrNickname(signupRequestVO.getEmail(),
                 signupRequestVO.getNickname());
         if (existingUser.isPresent()) {
-            throw new CustomException("이미 존재하는 닉네임입니다.");
+            throw new CustomException("이미 존재하는 닉네임입니다");
         }
 
         // 이메일 인증 여부 확인
         if (!redisUtil.exists(signupRequestVO.getEmail())) {
-            throw new CustomException("이메일 인증을 먼저 진행해 주세요.");
+            throw new CustomException("이메일 인증을 먼저 진행해 주세요");
         }
 
         // DTO → Entity 변환 / 엔티티의 password 컬럼에 암호화 된 값을 추가
@@ -59,21 +59,21 @@ public class UserServiceImpl implements UserService {
         userRepository.save(newUser);
         redisUtil.deleteData(signupRequestVO.getEmail());
 
-        return "회원가입이 완료되었습니다.";
+        return "회원가입이 완료되었습니다";
     }
 
     @Override
     public LoginResponseVO findMemberInfoById(Long userId) {
         return userRepository.findById(userId)
                 .map(LoginResponseVO::of)
-                .orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다."));
+                .orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
     }
 
     @Override
     public LoginResponseVO findMemberInfoByEmail(String email) {
         return userRepository.findByEmail(email)
                 .map(LoginResponseVO::of)
-                .orElseThrow(() -> new RuntimeException("유저 정보가 없습니다."));
+                .orElseThrow(() -> new RuntimeException("유저 정보가 없습니다"));
     }
 
     @Override
@@ -90,17 +90,17 @@ public class UserServiceImpl implements UserService {
     public ResponseEntity<String> verifyEmailAuthentication(EmailCheckDTO emailCheckDto) {
         // 이메일 중복 확인
         if (isEmailRegistered(emailCheckDto.getEmail())) {
-            return ResponseEntity.badRequest().body("이미 가입된 이메일입니다.");
+            return ResponseEntity.badRequest().body("이미 가입된 이메일입니다");
         }
 
         // 인증번호 직접 검증
         String storedAuthNum = redisUtil.getData(emailCheckDto.getEmail());
 
         if (storedAuthNum == null || !storedAuthNum.equals(emailCheckDto.getAuthNum())) {
-            return ResponseEntity.badRequest().body("인증 번호가 일치하지 않습니다.");
+            return ResponseEntity.badRequest().body("인증 번호가 일치하지 않습니다");
         }
 
-        return ResponseEntity.ok("인증 성공");
+        return ResponseEntity.ok("메일 인증이 완료 되었습니다");
     }
 
     // login 할때 자동 호출될 메소드

--- a/user-server/src/main/java/com/microsoftwo/clother/user/vo/SignupRequestVO.java
+++ b/user-server/src/main/java/com/microsoftwo/clother/user/vo/SignupRequestVO.java
@@ -13,16 +13,17 @@ import lombok.NoArgsConstructor;
 @Getter
 public class SignupRequestVO {
 
-    @Email
-    @NotEmpty(message = "이메일을 입력해 주세요.")
+    @Email(message = "올바른 형식의 이메일 주소를 입력해주세요")
+    @NotEmpty(message = "이메일을 입력해 주세요")
     private String email;
 
-    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
-    @NotEmpty(message = "비밀번호를 입력해 주세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상이어야 합니다")
+    @NotEmpty(message = "비밀번호를 입력해 주세요")
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}\\[\\]:;\"'<>,.?/]).+$",
             message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다")
     private String password;
 
+    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하이어야 합니다.")
     @NotEmpty(message = "닉네임을 입력해 주세요")
     private String nickname;
 
@@ -33,10 +34,4 @@ public class SignupRequestVO {
     private int height;
 
     private int weight;
-
-    public void setGender(String gender) {
-        if (gender != null) {
-            this.gender = gender.toUpperCase();  // 소문자를 대문자로 변환
-        }
-    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #100 

## 📝작업 내용

> 인증 코드 발송 테스트 시 인증 코드만 떴었는데, "인증 코드가 이메일로 발송되었습니다" 라는 문구 추가 하였습니다.

### 스크린샷 
<img width="881" alt="image" src="https://github.com/user-attachments/assets/15a953d6-07b2-455b-b04c-d70870459ab8" />


## 💬리뷰 요구사항(선택)

