### PR TITLE
[feat] 이미지 삭제 api 추가

### DIFF
--- a/image-service/src/main/java/com/microsoftwo/imageservice/controller/S3Controller.java
+++ b/image-service/src/main/java/com/microsoftwo/imageservice/controller/S3Controller.java
@@ -1,10 +1,13 @@
 package com.microsoftwo.imageservice.controller;
 
 import com.microsoftwo.imageservice.service.S3Service;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,5 +33,11 @@ public class S3Controller {
     public ResponseEntity<String> getPresignedUrl(@RequestParam String fileName) {
         String presignedUrl = s3Service.generatePresignedUrl(fileName);
         return ResponseEntity.ok(presignedUrl);
+    }
+
+    @DeleteMapping("/object")
+    public ResponseEntity<String> deleteUploadedObject(@RequestBody List<String> fileNames) {
+        s3Service.deleteObjects(fileNames);
+        return ResponseEntity.ok("삭제 완료");
     }
 }

--- a/image-service/src/main/java/com/microsoftwo/imageservice/service/S3Service.java
+++ b/image-service/src/main/java/com/microsoftwo/imageservice/service/S3Service.java
@@ -1,5 +1,9 @@
 package com.microsoftwo.imageservice.service;
 
+import java.util.List;
+
 public interface S3Service {
     String generatePresignedUrl(String fileName);
+
+    void deleteObjects(List<String> fileNames);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #110 

## 📝작업 내용

> POST 요청 실패 시 불필요한 메모리 점유를 방지하기 위한 S3에 있는 이미지 삭제 API 입니다.
