### PR TITLE
[fix] created_at 정렬 기준 추가

### DIFF
--- a/core-service/src/main/resources/com/microsoftwo/clother/post/query/dao/QueryPostMapper.xml
+++ b/core-service/src/main/resources/com/microsoftwo/clother/post/query/dao/QueryPostMapper.xml
@@ -67,7 +67,21 @@
                 AND u.weight &lt;= #{maxWeight}
             </if>
             <if test="lastPostId != null and sort == 'latest'">
-                AND p.id &lt; #{lastPostId}
+                AND (
+                    p.created_at &lt; (
+                        SELECT created_at
+                          FROM post
+                         WHERE id = #{lastPostId}
+                    )
+                    OR (
+                        p.created_at = (
+                            SELECT created_at
+                              FROM post
+                             WHERE id = #{lastPostId}
+                        )
+                    AND p.id &lt; #{lastPostId}
+                    )
+                )
             </if>
             <if test="lastPostId != null and sort == 'likes'">
                 AND (


### PR DESCRIPTION
## 📝작업 내용

> 기존 postId로만 정렬했었는데 테스트를 위해 created_at을 랜덤하게 update 하니 오류 발생하여 created_at 기준 추가했습니다.
